### PR TITLE
Add "ovr" before override property names

### DIFF
--- a/lib/src/pbdl/pbdl_override_property.dart
+++ b/lib/src/pbdl/pbdl_override_property.dart
@@ -44,7 +44,9 @@ class PBDLOverrideProperty extends PBDLNode implements PBDLNodeFactory {
           null,
           null,
           null,
-        );
+        ) {
+    this.name = 'ovr' + name;
+  }
 
   factory PBDLOverrideProperty.fromJson(Map<String, dynamic> json) =>
       _$PBDLOverridePropertyFromJson(json);


### PR DESCRIPTION
This prevents errors when the first character of an override property is invalid, such as a digit or symbol.