### PR TITLE
added abstract figmaRule class

### DIFF
--- a/lib/src/pbdl/abstract_figma_rule.dart
+++ b/lib/src/pbdl/abstract_figma_rule.dart
@@ -1,0 +1,16 @@
+import 'package:pbdl/src/pbdl/pbdl_node.dart';
+
+abstract class FigmaRule {
+  // to hold the name of the rule being checked
+  String name;
+
+  // to hold additional description of the rule if needed.
+  String description;
+
+  // Receives a list of nodes and validates the rule
+  bool validateRule(List<PBDLNode> nodesList);
+
+  // executes an action that may need to be performed
+  // after the rule is evaluated.
+  void executeAction();
+}


### PR DESCRIPTION
FigmaRule Class is an abstract class that should hold all the information related to rules to be checked before passing FigmaNodes to PBDLNodes.

Corresponding github issue :
https://github.com/Parabeac/parabeac_core/issues/643
