### PR TITLE
Fix/clean name global colors

### DIFF
--- a/lib/src/input/figma/entities/style/fill/fill_type.dart
+++ b/lib/src/input/figma/entities/style/fill/fill_type.dart
@@ -92,7 +92,7 @@ class SolidFillType implements FigmaFill {
   @override
   FigmaFill createFigmaFill(Map<String, dynamic> json) {
     // Added opacity on alpha
-    json['color']['a'] = json['opacity'];
+    json['color']['a'] ??= json['opacity'];
 
     return SolidFillType.fromJson(json);
   }

--- a/lib/src/input/figma/entities/style/fill/fill_type.dart
+++ b/lib/src/input/figma/entities/style/fill/fill_type.dart
@@ -92,7 +92,7 @@ class SolidFillType implements FigmaFill {
   @override
   FigmaFill createFigmaFill(Map<String, dynamic> json) {
     // Added opacity on alpha
-    json['color']['a'] ??= json['opacity'];
+    json['color']['a'] = json['opacity'] ?? json['color']['a'];
 
     return SolidFillType.fromJson(json);
   }

--- a/lib/src/pbdl/global_styles/pbdl_global_style.dart
+++ b/lib/src/pbdl/global_styles/pbdl_global_style.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:pbdl/pbdl.dart';
+import 'package:pbdl/src/input/general_helper/input_formatter.dart';
 
 @JsonSerializable(explicitToJson: true)
 
@@ -11,5 +12,8 @@ abstract class PBDLGlobalStyle extends PBDLNode {
     String UUID,
     String name, {
     this.description = '',
-  }) : super(UUID, name, false, null, null, null);
+  }) : super(UUID, name, false, null, null, null) {
+    /// Format variable name
+    this.name = PBInputFormatter.formatVariable(name);
+  }
 }


### PR DESCRIPTION
- Global variable names are formatted from the Abstract class 
- Fix a small bug where alpha in colors was being set as `null` causing incorrect hex generation